### PR TITLE
Make Web::Template::Mojo work

### DIFF
--- a/lib/Web/Template/Mojo.pm6
+++ b/lib/Web/Template/Mojo.pm6
@@ -8,26 +8,26 @@ class Web::Template::Mojo does Web::Template
   has @!paths  = './views';
 
   method render ($template-name, *%named, *@positional)
-  { ## Template::Mojo uses positional paramemters.
+  {
     my $template-file;
     my $template;
     for @!paths -> $path
     {
-      $template-file = $path ~ $template-name;
+      $template-file = IO::Spec.catfile($path, $template-name);
+      unless $template-file.IO ~~ :f {
+        $template-file = IO::Spec.catfile($path, $template-name ~ ".tm");
+      }
       if $template-file.IO ~~ :f
       {
         $template = slurp($template-file);
         last;
       }
     }
-    if $template.defined
-    {
-      $!engine.new($template).render(|@positional);
-    }
-    else
-    {
-      die "No template file for '$template-name' was found.";
-    }
+
+    $template orelse die "No template file for '$template-name' was found.";
+
+    ## Template::Mojo uses positional paramemters.
+    $!engine.new($template).render(%named.kv, |@positional);
   }
 
   method set-path (*@paths)


### PR DESCRIPTION
Looking for the template file always failed, due to a missing path
separator.

Templates named with the ".tm" extension weren't checked for.

Named parameters weren't passed along to the template, even though
a common idiom does use them (see eg/02-complex.tm in Template-Mojo).
